### PR TITLE
Establish DreamArtMachine core skeleton

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,18 @@
+"""Flask application for DreamArtMachine."""
+from __future__ import annotations
+
+from flask import Flask
+
+from config import configure_logging
+from routes import bp as routes_bp
+
+
+def create_app() -> Flask:
+    """Application factory."""
+    configure_logging()
+    app = Flask(__name__)
+    app.register_blueprint(routes_bp)
+    return app
+
+
+app = create_app()

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,0 +1,54 @@
+"""HTTP route definitions for DreamArtMachine."""
+from __future__ import annotations
+
+from flask import Blueprint, request
+from werkzeug.utils import secure_filename
+
+from config import (
+    UNANALYSED_ARTWORK_DIR,
+    FINALISED_ARTWORK_DIR,
+    sanitize_slug,
+    finalised_artwork_path,
+    mockup_path,
+)
+
+bp = Blueprint("routes", __name__)
+
+
+@bp.route("/upload", methods=["POST"])
+def upload() -> tuple[dict, int]:
+    file = request.files.get("file")
+    if not file or not file.filename:
+        return {"error": "no file provided"}, 400
+    filename = secure_filename(file.filename)
+    destination = UNANALYSED_ARTWORK_DIR / filename
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    file.save(destination)
+    return {"filename": filename}, 201
+
+
+@bp.route("/analyze/<provider>/<filename>", methods=["POST"])
+def analyze(provider: str, filename: str) -> tuple[dict, int]:
+    sanitized = secure_filename(filename)
+    target = UNANALYSED_ARTWORK_DIR / sanitized
+    if not target.exists():
+        return {"error": "file not found"}, 404
+    return {"provider": provider, "filename": sanitized}, 200
+
+
+@bp.route("/mockups/<slug>", methods=["POST"])
+def mockups(slug: str) -> tuple[dict, int]:
+    slug = sanitize_slug(slug)
+    slug_dir = FINALISED_ARTWORK_DIR / slug
+    slug_dir.mkdir(parents=True, exist_ok=True)
+    files = [str(mockup_path(slug, i)) for i in range(1, 10)]
+    return {"mockups": files}, 200
+
+
+@bp.route("/finalise/<slug>", methods=["POST"])
+def finalise(slug: str) -> tuple[dict, int]:
+    slug = sanitize_slug(slug)
+    final_path = finalised_artwork_path(slug)
+    if not final_path.exists():
+        return {"error": "final image missing"}, 404
+    return {"final": str(final_path)}, 200


### PR DESCRIPTION
## Summary
- set up Flask app factory and blueprint registration
- add configuration for paths, slug handling, and rotating logging
- scaffold upload, analysis, mockup, and finalisation routes

## Testing
- `python -m py_compile app.py`
- `python -m py_compile config.py`
- `python -m py_compile routes/__init__.py`
- `python - <<'PY'
import app
print('app loaded', isinstance(app.app, object))
PY`
- `python - <<'PY'
from config import (
    UNANALYSED_ARTWORK_DIR,
    PROCESSED_ARTWORK_DIR,
    FINALISED_ARTWORK_DIR,
    LOG_DIR,
    MOCKUPS_DIR,
)
print('unanalysed exists', UNANALYSED_ARTWORK_DIR.exists())
print('processed exists', PROCESSED_ARTWORK_DIR.exists())
print('finalised exists', FINALISED_ARTWORK_DIR.exists())
print('log exists', LOG_DIR.exists())
print('mockups exists', MOCKUPS_DIR.exists())
PY`
- `python - <<'PY'
import logging
from config import configure_logging, LOG_FILE
configure_logging()
logging.info('test log entry')
print('log file exists', LOG_FILE.exists())
print('log size', LOG_FILE.stat().st_size)
PY`


------
https://chatgpt.com/codex/tasks/task_e_6891eff5f3b8832ebc29ca723e2e07f8