### PR TITLE
Move analyzed artwork and trigger mockups

### DIFF
--- a/routes/analyze_routes.py
+++ b/routes/analyze_routes.py
@@ -7,6 +7,7 @@ from flask import Blueprint, request
 from werkzeug.utils import secure_filename
 
 from services.artwork_analysis_service import analyze_artwork
+from scripts.generate_composites import generate as generate_mockups
 
 bp = Blueprint("analysis", __name__)
 
@@ -22,9 +23,12 @@ def process_analysis_vision() -> tuple[dict, int]:
     filename = secure_filename(filename)
     try:
         slug = analyze_artwork(filename)
+        # Automatically generate mockup composites once analysis has
+        # completed successfully.
+        generate_mockups(slug)
     except FileNotFoundError:
         logger.error("File not found during analysis: %s", filename)
         return {"error": "file not found"}, 404
 
-    return {"status": "complete", "slug": slug}, 200
+    return {"slug": slug, "status": "complete"}, 200
 

--- a/services/artwork_analysis_service.py
+++ b/services/artwork_analysis_service.py
@@ -55,8 +55,11 @@ def analyze_artwork(filename: str) -> str:
     slug_dir.mkdir(parents=True, exist_ok=True)
 
     processed_image = processed_artwork_path(slug)
-    shutil.copyfile(source, processed_image)
-    logger.info("Copied artwork to %s", processed_image)
+    # Move the original file into the processed artwork directory
+    # instead of copying to ensure there is only a single source of
+    # truth for the artwork file.
+    shutil.move(str(source), processed_image)
+    logger.info("Moved artwork to %s", processed_image)
 
     analysis = _perform_analysis(processed_image)
     analysis_path = processed_analysis_path(slug)
@@ -104,9 +107,12 @@ def _update_master_paths(
 
     record = {
         slug: {
-            "image": str(image),
-            "analysis": str(analysis),
-            "openai": str(openai_img),
+            # Store absolute paths so downstream consumers have the
+            # correct locations regardless of the current working
+            # directory.
+            "image": str(image.resolve()),
+            "analysis": str(analysis.resolve()),
+            "openai": str(openai_img.resolve()),
         }
     }
 


### PR DESCRIPTION
## Summary
- move analyzed artwork into processed folder and record absolute paths
- generate mockups after analysis in processing route

## Testing
- `python -m py_compile services/artwork_analysis_service.py routes/analyze_routes.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892123c3654832ea0e51c86f13f3e8f