### PR TITLE
feat: add sku integrity validation and qa tooling

### DIFF
--- a/tests/test_validate_sku_integrity.py
+++ b/tests/test_validate_sku_integrity.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+from tools.validate_sku_integrity import check_unanalysed
+
+
+def test_missing_thumb(tmp_path):
+    base = tmp_path / "unanalysed-artwork"
+    base.mkdir()
+    (base / "image-RJC-0001.jpg").write_text("data")
+    (base / "image-RJC-0001-ANALYSE.jpg").write_text("data")
+    (base / "image-RJC-0001.json").write_text("{}")
+    errors = check_unanalysed(base)
+    assert any("THUMB" in e for e in errors)
+
+
+def test_all_files_present(tmp_path):
+    base = tmp_path / "unanalysed-artwork"
+    base.mkdir()
+    (base / "image-RJC-0002.jpg").write_text("data")
+    (base / "image-RJC-0002-ANALYSE.jpg").write_text("data")
+    (base / "image-RJC-0002-THUMB.jpg").write_text("data")
+    (base / "image-RJC-0002.json").write_text("{}")
+    errors = check_unanalysed(base)
+    assert errors == []

--- a/tools/validate_sku_integrity.py
+++ b/tools/validate_sku_integrity.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Validate SKU-based file integrity for DreamArtMachine.
+
+Scans the unanalysed and processed artwork directories to ensure that
+all required assets exist for each SKU. Missing components are logged
+and returned as errors.
+"""
+
+import json
+import logging
+import re
+import shutil
+from pathlib import Path
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+
+SKU_PATTERN = re.compile(r"RJC-[A-Za-z0-9-]+")
+
+
+def _extract_sku(name: str) -> str | None:
+    match = SKU_PATTERN.search(name)
+    return match.group(0) if match else None
+
+
+def check_unanalysed(base: Path) -> list[str]:
+    """Validate files in the unanalysed-artwork directory."""
+    errors: list[str] = []
+    if not base.exists():
+        logging.debug("Unanalysed directory %s does not exist", base)
+        return errors
+
+    for file in base.iterdir():
+        if not file.is_file() or file.suffix.lower() != ".jpg":
+            continue
+        if file.name.endswith("-THUMB.jpg") or file.name.endswith("-ANALYSE.jpg"):
+            continue
+        stem = file.stem
+        sku = _extract_sku(stem)
+        thumb = base / f"{stem}-THUMB.jpg"
+        analyse = base / f"{stem}-ANALYSE.jpg"
+        qc = base / f"{stem}.json"
+        if not thumb.exists():
+            errors.append(f"Missing THUMB for {sku or stem}")
+        if not analyse.exists():
+            errors.append(f"Missing ANALYSE for {sku or stem}")
+        if not qc.exists():
+            errors.append(f"Missing QC JSON for {sku or stem}")
+    return errors
+
+
+def check_processed(base: Path) -> list[str]:
+    """Validate files in the processed-artwork directory."""
+    errors: list[str] = []
+    if not base.exists():
+        logging.debug("Processed directory %s does not exist", base)
+        return errors
+
+    for folder in base.iterdir():
+        if not folder.is_dir():
+            continue
+        sku = None
+        for item in folder.iterdir():
+            sku = _extract_sku(item.name)
+            if sku:
+                break
+        if not sku:
+            errors.append(f"No SKU found in folder {folder.name}")
+            continue
+
+        slug = folder.name
+        main = folder / f"{slug}-{sku}.jpg"
+        thumb = folder / f"{slug}-{sku}-THUMB.jpg"
+        analyse = folder / f"{slug}-{sku}-ANALYSE.jpg"
+        qc = folder / f"{slug}-{sku}.json"
+        required = [
+            (main, "Main"),
+            (thumb, "THUMB"),
+            (analyse, "ANALYSE"),
+            (qc, "QC JSON"),
+        ]
+        for path, desc in required:
+            if not path.exists():
+                errors.append(f"Missing {desc} for {sku} in {slug}")
+
+        for i in range(1, 10):
+            mock = folder / f"{slug}-{sku}-MU-{i:02}.jpg"
+            if not mock.exists():
+                errors.append(f"Missing mockup MU-{i:02} for {sku} in {slug}")
+            thumb_dir = folder / "THUMBS"
+            mu_thumb = thumb_dir / f"{slug}-{sku}-MU-{i:02}-THUMB.jpg"
+            if not mu_thumb.exists():
+                errors.append(f"Missing mockup thumb MU-{i:02} for {sku} in {slug}")
+    return errors
+
+
+def validate(root: Path) -> list[str]:
+    """Run SKU integrity validation for both artwork directories."""
+    logging.info("Using Python interpreter at: %s", shutil.which("python") or "unknown")
+    root = root.resolve()
+    unanalysed = root / "art-processing" / "unanalysed-artwork"
+    processed = root / "art-processing" / "processed-artwork"
+    errors = check_unanalysed(unanalysed) + check_processed(processed)
+    if errors:
+        for err in errors:
+            logging.error(err)
+    else:
+        logging.info("All SKU assets validated")
+    return errors
+
+
+def main() -> int:
+    base = Path(__file__).resolve().parent.parent
+    errors = validate(base)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add SKU-based integrity validator script
- extend toolkit QA to include tests, SKU checks, pip status, and permission audit
- enhance system health, backups, and restore with validations and non-interactive options

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6892c9c353e0832ebdd04e8b06bbba09