### PR TITLE
Restore artwork upload pipeline with SKU tracking

### DIFF
--- a/config.py
+++ b/config.py
@@ -26,6 +26,10 @@ LOG_DIR = BASE_DIR / "logs"
 INPUTS_DIR = BASE_DIR / "inputs"
 MOCKUPS_DIR = INPUTS_DIR / "mockups"
 MASTER_ARTWORK_PATHS_FILE = BASE_DIR / "master-artwork-paths.json"
+# SKU tracking
+SKU_TRACKER = BASE_DIR / "sku_tracker.json"
+SKU_PREFIX = "ARTNARRATOR"
+SKU_DIGITS = 5
 
 # Ensure required directories exist
 for directory in [

--- a/routes/artwork_routes.py
+++ b/routes/artwork_routes.py
@@ -10,14 +10,21 @@ from flask import (
     redirect,
     render_template,
     request,
-    send_from_directory,
+    send_file,
     url_for,
 )
 from flask_login import login_required
-from werkzeug.utils import secure_filename
+from werkzeug.utils import secure_filename, safe_join
 
+import json
 import os
+from pathlib import Path
+from typing import List
+
+from PIL import Image
+
 import config
+from services.sku_service import get_next_sku
 
 bp = Blueprint("artwork", __name__)
 
@@ -27,18 +34,52 @@ ALLOWED_EXTENSIONS = {"jpg", "jpeg", "png"}
 # ==========================================================================
 # 1. Helpers
 # ==========================================================================
-def _unique_path(directory: Path, filename: str) -> Path:
-    """Return a unique path in ``directory`` avoiding overwrite."""
-    dest = directory / filename
-    if not dest.exists():
-        return dest
-    stem, suffix = dest.stem, dest.suffix
+def _unique_slug(base: Path, slug: str) -> Path:
+    """Return a unique directory path for ``slug`` within ``base``."""
+    candidate = base / slug
     counter = 1
-    while True:
-        candidate = directory / f"{stem}-{counter}{suffix}"
-        if not candidate.exists():
-            return candidate
+    while candidate.exists():
+        candidate = base / f"{slug}-{counter}"
         counter += 1
+    return candidate
+
+
+def _resize_long_edge(img: Image.Image, long_edge: int) -> Image.Image:
+    """Return a copy of ``img`` resized to ``long_edge`` on the longest side."""
+    w, h = img.size
+    if max(w, h) <= long_edge:
+        return img.copy()
+    if w >= h:
+        new_w = long_edge
+        new_h = int(long_edge * h / w)
+    else:
+        new_h = long_edge
+        new_w = int(long_edge * w / h)
+    return img.resize((new_w, new_h), Image.LANCZOS)
+
+
+def _dominant_colours(img: Image.Image, count: int = 5) -> List[str]:
+    """Return up to ``count`` dominant colours as hex strings."""
+    small = img.convert("RGB").resize((100, 100))
+    colours = small.getcolors(10000) or []
+    colours.sort(reverse=True, key=lambda c: c[0])
+    return ["#%02x%02x%02x" % tuple(colour[1]) for colour in colours[:count]]
+
+
+def _write_json(path: Path, data: dict) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _serve_from_base(base: Path, subpath: str):
+    try:
+        full = Path(safe_join(str(base), subpath))
+    except Exception:
+        abort(404)
+    if not full.exists():
+        abort(404)
+    return send_file(full)
 
 
 # ==========================================================================
@@ -47,7 +88,7 @@ def _unique_path(directory: Path, filename: str) -> Path:
 @bp.route("/upload", methods=["GET", "POST"])
 @login_required
 def upload_artwork():
-    """Handle new artwork file uploads."""
+    """Handle new artwork file uploads with derivative generation."""
     if request.method == "POST":
         files = request.files.getlist("file")
         if not files:
@@ -62,11 +103,43 @@ def upload_artwork():
             if ext not in ALLOWED_EXTENSIONS:
                 flash(f"❌ Invalid file type: {filename}", "error")
                 continue
-            save_path = _unique_path(config.UNANALYSED_ARTWORK_DIR, filename)
-            save_path.parent.mkdir(parents=True, exist_ok=True)
-            uploaded_file.save(save_path)
-            flash(f"✅ Uploaded: {save_path.name}", "success")
+
+            slug = config.sanitize_slug(Path(filename).stem)
+            target_dir = _unique_slug(config.UNANALYSED_ARTWORK_DIR, slug)
+            target_dir.mkdir(parents=True, exist_ok=True)
+
+            sku = get_next_sku(config.SKU_TRACKER)
+            original_path = target_dir / filename
+            uploaded_file.save(original_path)
+
+            with Image.open(original_path) as img:
+                img = img.convert("RGB")
+                thumb_img = _resize_long_edge(img, 2000)
+                analyse_img = _resize_long_edge(img, 3800)
+                thumb_path = target_dir / f"{sku}-THUMB.jpg"
+                analyse_path = target_dir / f"{sku}-ANALYSE.jpg"
+                thumb_img.save(thumb_path, "JPEG", quality=90)
+                analyse_img.save(analyse_path, "JPEG", quality=95)
+                qc = {
+                    "width": analyse_img.width,
+                    "height": analyse_img.height,
+                    "mode": analyse_img.mode,
+                    "dominant_colours": _dominant_colours(analyse_img),
+                }
+
+            meta = {
+                "sku": sku,
+                "original_filename": filename,
+                "slug": target_dir.name,
+                "thumb_path": f"{target_dir.name}/{thumb_path.name}",
+                "analyse_path": f"{target_dir.name}/{analyse_path.name}",
+                "qc": qc,
+            }
+            qc_path = target_dir / f"{sku}-QC.json"
+            _write_json(qc_path, meta)
+            flash(f"✅ Uploaded: {filename} as {sku}", "success")
         return redirect(url_for("artwork.upload_artwork"))
+
     return render_template(
         "upload.html",
         openai_configured=bool(os.getenv("OPENAI_API_KEY")),
@@ -81,30 +154,18 @@ def upload_artwork():
 @login_required
 def unanalysed_image(filename: str):
     """Serve raw uploaded artwork awaiting analysis."""
-    safe = secure_filename(filename)
-    path = config.UNANALYSED_ARTWORK_DIR / safe
-    if not path.exists():
-        abort(404)
-    return send_from_directory(config.UNANALYSED_ARTWORK_DIR, safe)
+    return _serve_from_base(config.UNANALYSED_ARTWORK_DIR, filename)
 
 
 @bp.route("/processed/<path:filename>")
 @login_required
 def processed_image(filename: str):
     """Serve processed artwork images."""
-    safe = secure_filename(filename)
-    path = config.PROCESSED_ARTWORK_DIR / safe
-    if not path.exists():
-        abort(404)
-    return send_from_directory(config.PROCESSED_ARTWORK_DIR, safe)
+    return _serve_from_base(config.PROCESSED_ARTWORK_DIR, filename)
 
 
 @bp.route("/finalised/<path:filename>")
 @login_required
 def finalised_image(filename: str):
     """Serve finalised artwork images."""
-    safe = secure_filename(filename)
-    path = config.FINALISED_ARTWORK_DIR / safe
-    if not path.exists():
-        abort(404)
-    return send_from_directory(config.FINALISED_ARTWORK_DIR, safe)
+    return _serve_from_base(config.FINALISED_ARTWORK_DIR, filename)

--- a/routes/home_routes.py
+++ b/routes/home_routes.py
@@ -6,6 +6,7 @@ from flask_login import login_required
 import os
 import config
 from routes import utils as routes_utils
+from datetime import datetime
 
 bp = Blueprint("home", __name__)
 
@@ -33,6 +34,10 @@ def home() -> str:
 def artworks() -> str:
     """List all unanalysed artworks ready for processing."""
     artworks = routes_utils.get_all_unanalysed_artworks()
+    for art in artworks:
+        art["upload_date"] = datetime.fromtimestamp(art["timestamp"]).strftime(
+            "%Y-%m-%d"
+        )
     return render_template(
         "artworks.html",
         artworks=artworks,

--- a/services/sku_service.py
+++ b/services/sku_service.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+from config import SKU_DIGITS, SKU_PREFIX
+
+logger = logging.getLogger(__name__)
+
+
+def get_next_sku(tracker: Path) -> str:
+    """Return the next sequential SKU and update ``tracker``.
+
+    The tracker JSON stores the last used number. This function is
+    intentionally simple and not meant for heavy concurrency.
+    """
+    tracker.parent.mkdir(parents=True, exist_ok=True)
+    last = 0
+    if tracker.exists():
+        try:
+            data = json.loads(tracker.read_text())
+            last = int(data.get("last", 0))
+        except Exception as exc:  # pragma: no cover - corrupt tracker
+            logger.warning("Failed reading SKU tracker %s: %s", tracker, exc)
+    next_num = last + 1
+    tracker.write_text(json.dumps({"last": next_num}))
+    sku = f"{SKU_PREFIX}-{next_num:0{SKU_DIGITS}d}"
+    logger.info("Assigned new SKU %s", sku)
+    return sku

--- a/static/js/artworks.js
+++ b/static/js/artworks.js
@@ -9,7 +9,7 @@ document.addEventListener('DOMContentLoaded', () => {
       if (!card) return;
       
       const provider = btn.dataset.provider;
-      const filename = card.dataset.filename;
+      const filename = card.dataset.analyse;
       
       if (!filename || !provider) {
         alert('Error: Missing filename or provider information.');

--- a/templates/artworks.html
+++ b/templates/artworks.html
@@ -7,10 +7,11 @@
   {% if artworks %}
   <div class="gallery-grid">
     {% for art in artworks %}
-    <div class="gallery-card" data-filename="{{ art.filename }}" data-aspect="{{ art.aspect }}">
-      <img src="{{ get_artwork_image_url('unanalysed', art.filename) }}" alt="{{ art.slug }}" class="card-img-top">
+    <div class="gallery-card" data-analyse="{{ art.analyse }}" data-aspect="{{ art.aspect }}" data-sku="{{ art.sku }}">
+      <img src="{{ get_artwork_image_url('unanalysed', art.thumb) }}" alt="{{ art.slug }}" class="card-img-top">
       <div class="card-body">
-        <h3 class="card-title">{{ art.slug }}</h3>
+        <h3 class="card-title">{{ art.filename }}</h3>
+        <div class="card-meta">SKU: {{ art.sku }}<br>Uploaded: {{ art.upload_date }}</div>
         <button class="btn btn-primary btn-analyze" data-provider="openai">Analyze</button>
       </div>
       <div class="card-overlay hidden"></div>

--- a/tests/test_restore_integrity.py
+++ b/tests/test_restore_integrity.py
@@ -9,25 +9,27 @@ from tools.validate_sku_integrity import validate
 def test_restore_integrity(tmp_path):
     root = tmp_path
     (root / ".env").write_text("TEST=1")
-    unanalysed = root / "art-processing" / "unanalysed-artwork"
+    unanalysed = root / "art-processing" / "unanalysed-artwork" / "img"
     unanalysed.mkdir(parents=True)
-    (unanalysed / "img-RJC-1.jpg").write_text("x")
-    (unanalysed / "img-RJC-1-THUMB.jpg").write_text("x")
-    (unanalysed / "img-RJC-1-ANALYSE.jpg").write_text("x")
-    (unanalysed / "img-RJC-1.json").write_text("{}")
+    sku1 = "ARTNARRATOR-00001"
+    (unanalysed / "img.jpg").write_text("x")
+    (unanalysed / f"{sku1}-THUMB.jpg").write_text("x")
+    (unanalysed / f"{sku1}-ANALYSE.jpg").write_text("x")
+    (unanalysed / f"{sku1}-QC.json").write_text("{}")
 
     processed = root / "art-processing" / "processed-artwork" / "slug"
     thumbs = processed / "THUMBS"
     thumbs.mkdir(parents=True)
-    sku = "RJC-1"
-    (processed / f"slug-{sku}.jpg").write_text("x")
-    (processed / f"slug-{sku}-THUMB.jpg").write_text("x")
-    (processed / f"slug-{sku}-ANALYSE.jpg").write_text("x")
-    (processed / f"slug-{sku}.json").write_text("{}")
-    (processed / f"final-slug-{sku}.json").write_text("{}")
+    sku2 = "ARTNARRATOR-12345"
+    slug = processed.name
+    (processed / f"{slug}-{sku2}.jpg").write_text("x")
+    (processed / f"{slug}-{sku2}-THUMB.jpg").write_text("x")
+    (processed / f"{slug}-{sku2}-ANALYSE.jpg").write_text("x")
+    (processed / f"{sku2}-QC.json").write_text("{}")
+    (processed / f"{sku2}-FINAL.json").write_text("{}")
     for i in range(1, 10):
-        (processed / f"slug-{sku}-MU-{i:02}.jpg").write_text("x")
-        (thumbs / f"slug-{sku}-MU-{i:02}-THUMB.jpg").write_text("x")
+        (processed / f"{slug}-{sku2}-MU-{i:02}.jpg").write_text("x")
+        (thumbs / f"{slug}-{sku2}-MU-{i:02}-THUMB.jpg").write_text("x")
 
     errors = validate(root)
     assert errors == []

--- a/tests/test_validate_sku_integrity.py
+++ b/tests/test_validate_sku_integrity.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import sys
+from pathlib import Path
+import sys
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
@@ -7,23 +9,25 @@ from tools.validate_sku_integrity import check_unanalysed, check_processed
 
 
 def test_missing_thumb(tmp_path):
-    base = tmp_path / "unanalysed-artwork"
-    base.mkdir()
-    (base / "image-RJC-0001.jpg").write_text("data")
-    (base / "image-RJC-0001-ANALYSE.jpg").write_text("data")
-    (base / "image-RJC-0001.json").write_text("{}")
-    errors = check_unanalysed(base)
+    root = tmp_path / "unanalysed-artwork" / "image"
+    root.mkdir(parents=True)
+    sku = "ARTNARRATOR-00001"
+    (root / "image.jpg").write_text("data")
+    (root / f"{sku}-ANALYSE.jpg").write_text("data")
+    (root / f"{sku}-QC.json").write_text("{}")
+    errors = check_unanalysed(tmp_path / "unanalysed-artwork")
     assert any("THUMB" in e for e in errors)
 
 
 def test_all_files_present(tmp_path):
-    base = tmp_path / "unanalysed-artwork"
-    base.mkdir()
-    (base / "image-RJC-0002.jpg").write_text("data")
-    (base / "image-RJC-0002-ANALYSE.jpg").write_text("data")
-    (base / "image-RJC-0002-THUMB.jpg").write_text("data")
-    (base / "image-RJC-0002.json").write_text("{}")
-    errors = check_unanalysed(base)
+    root = tmp_path / "unanalysed-artwork" / "image"
+    root.mkdir(parents=True)
+    sku = "ARTNARRATOR-00002"
+    (root / "image.jpg").write_text("data")
+    (root / f"{sku}-ANALYSE.jpg").write_text("data")
+    (root / f"{sku}-THUMB.jpg").write_text("data")
+    (root / f"{sku}-QC.json").write_text("{}")
+    errors = check_unanalysed(tmp_path / "unanalysed-artwork")
     assert errors == []
 
 
@@ -31,12 +35,12 @@ def test_processed_missing_final_json(tmp_path):
     base = tmp_path / "processed-artwork" / "slug"
     thumbs = base / "THUMBS"
     thumbs.mkdir(parents=True)
-    sku = "RJC-1234"
+    sku = "ARTNARRATOR-12345"
     slug = base.name
     (base / f"{slug}-{sku}.jpg").write_text("data")
     (base / f"{slug}-{sku}-THUMB.jpg").write_text("data")
     (base / f"{slug}-{sku}-ANALYSE.jpg").write_text("data")
-    (base / f"{slug}-{sku}.json").write_text("{}")
+    (base / f"{sku}-QC.json").write_text("{}")
     for i in range(1, 10):
         (base / f"{slug}-{sku}-MU-{i:02}.jpg").write_text("mu")
         (thumbs / f"{slug}-{sku}-MU-{i:02}-THUMB.jpg").write_text("mu")
@@ -48,13 +52,13 @@ def test_processed_complete(tmp_path):
     base = tmp_path / "processed-artwork" / "slug2"
     thumbs = base / "THUMBS"
     thumbs.mkdir(parents=True)
-    sku = "RJC-5678"
+    sku = "ARTNARRATOR-56789"
     slug = base.name
     (base / f"{slug}-{sku}.jpg").write_text("data")
     (base / f"{slug}-{sku}-THUMB.jpg").write_text("data")
     (base / f"{slug}-{sku}-ANALYSE.jpg").write_text("data")
-    (base / f"{slug}-{sku}.json").write_text("{}")
-    (base / f"final-{slug}-{sku}.json").write_text("{}")
+    (base / f"{sku}-QC.json").write_text("{}")
+    (base / f"{sku}-FINAL.json").write_text("{}")
     for i in range(1, 10):
         (base / f"{slug}-{sku}-MU-{i:02}.jpg").write_text("mu")
         (thumbs / f"{slug}-{sku}-MU-{i:02}-THUMB.jpg").write_text("mu")


### PR DESCRIPTION
## Summary
- add SKU tracker and generator service
- generate image derivatives and QC metadata on upload
- list unprocessed artworks via QC JSON with SKU info

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68942125c9ac832e8eb2ed19f079061f