### PR TITLE
Fix artwork gallery loading and expand layout

### DIFF
--- a/CODEX-LOGS/2025-08-07-CODEX-LOG.md
+++ b/CODEX-LOGS/2025-08-07-CODEX-LOG.md
@@ -1,0 +1,23 @@
+# 2025-08-07 Codex Log
+
+## Summary
+- Fixed `/artworks` gallery failing to load after uploads.
+- Redirected uploads to artwork gallery.
+- Expanded layout to 2400px with full-width header and footer.
+- Added placeholders and safer file handling for missing thumbnails.
+
+## Files Modified
+- `routes/artwork_routes.py`
+- `routes/home_routes.py`
+- `routes/utils.py`
+- `templates/artworks.html`
+- `static/css/style.css`
+- `static/css/layout.css`
+- `static/css/art-cards.css`
+
+## Testing
+- `pytest`
+
+## Notes
+- Further QA on real artwork data recommended.
+

--- a/routes/artwork_routes.py
+++ b/routes/artwork_routes.py
@@ -1,6 +1,12 @@
 from __future__ import annotations
 
 
+"""Artwork upload and serving routes.
+
+This module handles incoming uploads, derivative generation and the serving of
+images at various stages of the workflow.
+"""
+
 from pathlib import Path
 
 from flask import (
@@ -18,7 +24,6 @@ from werkzeug.utils import secure_filename, safe_join
 
 import json
 import os
-from pathlib import Path
 from typing import List
 
 from PIL import Image
@@ -138,7 +143,7 @@ def upload_artwork():
             qc_path = target_dir / f"{sku}-QC.json"
             _write_json(qc_path, meta)
             flash(f"✅ Uploaded: {filename} as {sku}", "success")
-        return redirect(url_for("artwork.upload_artwork"))
+        return redirect(url_for("home.artworks"))
 
     return render_template(
         "upload.html",

--- a/routes/home_routes.py
+++ b/routes/home_routes.py
@@ -1,14 +1,23 @@
+"""Home and gallery routes.
+
+Provides landing pages and the unanalysed artwork gallery.
+"""
+
 from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
 
 from flask import Blueprint, redirect, render_template, url_for
 from flask_login import login_required
 
-import os
 import config
 from routes import utils as routes_utils
-from datetime import datetime
 
 bp = Blueprint("home", __name__)
+
+logger = logging.getLogger(__name__)
 
 
 @bp.route("/")
@@ -33,11 +42,17 @@ def home() -> str:
 @login_required
 def artworks() -> str:
     """List all unanalysed artworks ready for processing."""
-    artworks = routes_utils.get_all_unanalysed_artworks()
+    try:
+        artworks = routes_utils.get_all_unanalysed_artworks()
+    except Exception as exc:  # pragma: no cover - defensive coding
+        logger.error("Failed to collect unanalysed artworks: %s", exc)
+        artworks = []
+
     for art in artworks:
         art["upload_date"] = datetime.fromtimestamp(art["timestamp"]).strftime(
             "%Y-%m-%d"
         )
+
     return render_template(
         "artworks.html",
         artworks=artworks,

--- a/routes/utils.py
+++ b/routes/utils.py
@@ -63,6 +63,7 @@ def get_all_unanalysed_artworks() -> List[Dict[str, Any]]:
     for folder in sorted(directory.iterdir()):
         if not folder.is_dir():
             continue
+
         qc_file = next(folder.glob("*-QC.json"), None)
         if not qc_file:
             continue
@@ -71,30 +72,41 @@ def get_all_unanalysed_artworks() -> List[Dict[str, Any]]:
         except json.JSONDecodeError:
             logger.warning("Invalid QC JSON: %s", qc_file)
             continue
+
         sku = data.get("sku")
         thumb_rel = data.get("thumb_path")
         analyse_rel = data.get("analyse_path")
         original_name = data.get("original_filename")
-        if not (sku and thumb_rel and analyse_rel and original_name):
+        if not (sku and original_name):
             continue
+
         original = folder / original_name
-        thumb = directory / thumb_rel
-        analyse = directory / analyse_rel
-        if not (original.exists() and thumb.exists() and analyse.exists()):
-            logger.debug("Skipping incomplete artwork in %s", folder)
+        if not original.exists():
+            logger.debug("Original missing for %s", folder)
             continue
+
+        thumb = directory / thumb_rel if thumb_rel else None
+        analyse = directory / analyse_rel if analyse_rel else None
+        thumb_ok = thumb and thumb.exists()
+        analyse_ok = analyse and analyse.exists()
+        if not thumb_ok:
+            logger.warning("Missing thumbnail for %s", folder)
+        if not analyse_ok:
+            logger.warning("Missing analyse image for %s", folder)
+
         if sku and any(processed_dir.glob(f"*/**{sku}*")):
             # already processed
             continue
-        aspect = _aspect_from_image(analyse)
+
+        aspect = _aspect_from_image(analyse) if analyse_ok else "unknown"
         ts = original.stat().st_mtime
         artworks.append(
             {
                 "filename": original_name,
                 "slug": data.get("slug", folder.name),
                 "sku": sku,
-                "thumb": thumb_rel,
-                "analyse": analyse_rel,
+                "thumb": thumb_rel if thumb_ok else None,
+                "analyse": analyse_rel if analyse_ok else None,
                 "aspect": aspect,
                 "timestamp": ts,
             }

--- a/static/css/art-cards.css
+++ b/static/css/art-cards.css
@@ -12,6 +12,17 @@
 .gallery-card:hover { box-shadow: 0 0.25rem 1rem #0002; transform: translateY(-0.25rem) scale(1.013);}
 .card-thumb { width: 100%; background: none; text-align: center; padding: 1.375rem 0 0.4375rem 0; }
 .card-img-top { max-width: 94%; max-height: 13.125rem; object-fit: cover; box-shadow: 0 0.0625rem 0.4375rem #0001; background: var(--color-background);}
+.card-img-top.placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 94%;
+  max-width: 94%;
+  height: 13.125rem;
+  max-height: 13.125rem;
+  background: var(--color-card-bg);
+  color: var(--color-text);
+}
 .card-details { flex: 1 1 auto; width: 100%; text-align: center; padding: 0.75rem 0.8125rem 1.25rem 0.8125rem; display: flex; flex-direction: column; gap: 0.625rem;}
 .card-title { font-size: 0.9em; font-weight: 400; line-height: 1.2; color: var(--main-txt); min-height: 3em; margin-bottom: 0.4375rem;}
 .card-details .btn { margin-top: 0.4375rem; width: 90%; min-width: 5.625rem;}

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -69,13 +69,17 @@
 
 
 /* === Header === */
-.site-header, .overlay-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: center;
-	padding: 1rem 1rem;
-	width: 100%;
-	background-color: var(--header-bg);
+.site-header,
+.overlay-header {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 1rem 1rem;
+        width: 100vw;
+        margin: 0 auto;
+        left: 0;
+        right: 0;
+        background-color: var(--header-bg);
 }
 
 .site-header {
@@ -135,13 +139,18 @@
         flex-direction: column;
         justify-content: center;
         border-top: 1px solid var(--color-footer-border);
+        width: 100vw;
+        margin-left: 0;
+        margin-right: 0;
+        left: 0;
+        right: 0;
 }
 
 .footer-grid {
         display: grid;
         grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
         gap: 1rem;
-        max-width: 75rem;
+        max-width: 2400px;
         width: 100%;
         margin: 0 auto;
         padding: 0 2rem;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -86,7 +86,7 @@ main { flex-grow: 1; }
   max-width: 2400px;
   width: 100%;
   margin: 0 auto;
-  padding: .25rem 2rem 2rem 2rem;
+  padding: 0 2rem;
   box-sizing: border-box;
 }
 
@@ -112,15 +112,6 @@ textarea, input[type="text"], input[type="email"], input[type="password"], selec
 @media (min-width: 768px) and (max-width: 1023px) {
   .container { padding: 1.5rem 1rem; }
 }
-/* Laptops */
-@media (min-width: 1024px) and (max-width: 1439px) {
-  .container { max-width: 94vw; }
-}
-/* Standard Desktops */
-@media (min-width: 1440px) and (max-width: 2399px) {
-  .container { max-width: 90vw; }
-}
-/* Ultra-Wide Monitors */
 @media (min-width: 2400px) {
   .container { max-width: 2400px; }
 }

--- a/templates/artworks.html
+++ b/templates/artworks.html
@@ -7,8 +7,12 @@
   {% if artworks %}
   <div class="gallery-grid">
     {% for art in artworks %}
-    <div class="gallery-card" data-analyse="{{ art.analyse }}" data-aspect="{{ art.aspect }}" data-sku="{{ art.sku }}">
+    <div class="gallery-card" data-analyse="{{ art.analyse or '' }}" data-aspect="{{ art.aspect }}" data-sku="{{ art.sku }}">
+      {% if art.thumb %}
       <img src="{{ get_artwork_image_url('unanalysed', art.thumb) }}" alt="{{ art.slug }}" class="card-img-top">
+      {% else %}
+      <div class="card-img-top placeholder">No thumbnail</div>
+      {% endif %}
       <div class="card-body">
         <h3 class="card-title">{{ art.filename }}</h3>
         <div class="card-meta">SKU: {{ art.sku }}<br>Uploaded: {{ art.upload_date }}</div>


### PR DESCRIPTION
## Summary
- redirect uploads to artwork gallery after processing
- harden artwork listing to skip corrupt entries and show placeholders
- expand content width and enforce full-width header and footer

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894363c4868832e86a4e99d9fe71d2f