### PR TITLE
Migrate to SQLAlchemy-backed authentication

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-"""Flask application for DreamArtMachine with basic authentication."""
+"""Flask application for DreamArtMachine with database-backed authentication."""
 
 from __future__ import annotations
 
@@ -10,15 +10,6 @@ from flask import (
     render_template,
     request,
     url_for,
-    flash,
-)
-from flask_login import (
-    LoginManager,
-    UserMixin,
-    current_user,
-    login_required,
-    login_user,
-    logout_user,
 )
 
 from config import configure_logging
@@ -32,30 +23,17 @@ from routes.exports_routes import bp as exports_bp
 from routes.analyze_routes import bp as analyze_bp
 
 
-login_manager = LoginManager()
-login_manager.login_view = "login"
-
-
-class User(UserMixin):
-    """Minimal user model for authentication."""
-
-    def __init__(self, username: str):
-        self.id = username
-        self.username = username
-
-
-USERS = {"robbie": {"password": "Kanga123!"}, "backup": {"password": "DreamArt@2025"}}
-
-
-@login_manager.user_loader
-def load_user(user_id: str) -> User | None:  # pragma: no cover - simple loader
-    user = USERS.get(user_id)
-    return User(user_id) if user else None
+from db import init_db
+from routes.auth_routes import bp as auth_bp
+from utils.security import is_authenticated
+from utils.user_manager import ensure_default_users
 
 
 def create_app() -> Flask:
     """Application factory with security settings and login enforcement."""
     configure_logging()
+    init_db()
+    ensure_default_users()
     app = Flask(__name__)
     app.config.update(
         SECRET_KEY=os.environ.get("SECRET_KEY", "dev"),
@@ -64,46 +42,15 @@ def create_app() -> Flask:
         REMEMBER_COOKIE_SECURE=True,
         PREFERRED_URL_SCHEME="https",
     )
-    login_manager.init_app(app)
 
     @app.before_request
     def require_login() -> None:
         """Redirect users to login page if not authenticated."""
-        exempt = {"login", "static"}
+        exempt = {"auth.login", "static"}
         if request.endpoint in exempt or request.path == "/favicon.ico":
             return
-        if not current_user.is_authenticated:
-            return redirect(url_for("login"))
-
-    @app.route("/login", methods=["GET", "POST"])
-    def login():
-        if request.method == "POST":
-            username = request.form.get("username", "")
-            password = request.form.get("password", "")
-            user = USERS.get(username)
-            if user and user["password"] == password:
-                login_user(User(username))
-                return redirect(url_for("home.home"))
-            flash("Invalid credentials", "error")
-        return render_template("login.html")
-
-    @app.route("/logout")
-    @login_required
-    def logout():
-        logout_user()
-        return redirect(url_for("login"))
-
-    # Artwork listing handled in home blueprint
-
-    @app.route("/healthz")
-    @login_required
-    def health_check() -> tuple[str, int]:
-        return "OK", 200
-
-    @app.route("/whoami")
-    @login_required
-    def whoami() -> tuple[str, int]:
-        return f"Logged in as: {current_user.username}", 200
+        if not is_authenticated():
+            return redirect(url_for("auth.login"))
 
     @app.errorhandler(404)
     def not_found(_e):
@@ -113,6 +60,7 @@ def create_app() -> Flask:
     def server_error(_e):
         return render_template("500.html"), 500
 
+    app.register_blueprint(auth_bp)
     app.register_blueprint(home_bp)
     app.register_blueprint(artwork_bp)
     app.register_blueprint(routes_bp)

--- a/art-processing/finalised-artwork/ap_test_restore_integrity.py
+++ b/art-processing/finalised-artwork/ap_test_restore_integrity.py
@@ -1,7 +1,8 @@
 from pathlib import Path
 import sys
 
-ROOT = Path(__file__).resolve().parents[1]
+# Add project root to import path
+ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(ROOT))
 from tools.validate_sku_integrity import validate
 

--- a/config.py
+++ b/config.py
@@ -26,6 +26,8 @@ LOG_DIR = BASE_DIR / "logs"
 INPUTS_DIR = BASE_DIR / "inputs"
 MOCKUPS_DIR = INPUTS_DIR / "mockups"
 MASTER_ARTWORK_PATHS_FILE = BASE_DIR / "master-artwork-paths.json"
+# Database
+DB_PATH = BASE_DIR / "dream.db"
 # SKU tracking
 SKU_TRACKER = BASE_DIR / "sku_tracker.json"
 SKU_PREFIX = "RJC"

--- a/db.py
+++ b/db.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+"""Database setup for DreamArtMachine."""
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker, declarative_base
+
+from config import DB_PATH
+
+engine = create_engine(
+    f"sqlite:///{DB_PATH}", connect_args={"check_same_thread": False}
+)
+SessionLocal = scoped_session(sessionmaker(bind=engine, autocommit=False, autoflush=False))
+Base = declarative_base()
+
+
+def init_db() -> None:
+    """Create database tables."""
+    Base.metadata.create_all(bind=engine)
+
+
+def get_session():
+    """Return a new database session."""
+    return SessionLocal()

--- a/routes/admin_routes.py
+++ b/routes/admin_routes.py
@@ -3,19 +3,16 @@
 from __future__ import annotations
 
 from flask import Blueprint, render_template
-from flask_login import login_required
 
 bp = Blueprint("admin", __name__, url_prefix="/admin")
 
 
 @bp.route("/dashboard")
-@login_required
 def dashboard():
     return render_template("admin/dashboard.html")
 
 
 @bp.route("/security")
-@login_required
 def security_page():
     context = {
         "login_required": True,
@@ -29,7 +26,6 @@ def security_page():
 
 
 @bp.route("/users")
-@login_required
 def manage_users():
     return render_template(
         "admin/users.html", users=[], config={"ADMIN_USERNAME": "admin"}
@@ -37,12 +33,10 @@ def manage_users():
 
 
 @bp.route("/mockups")
-@login_required
 def mockups():
     return render_template("admin/mockups.html")
 
 
 @bp.route("/coordinates")
-@login_required
 def coordinates():
     return render_template("admin/coordinates.html")

--- a/routes/analyze_routes.py
+++ b/routes/analyze_routes.py
@@ -1,7 +1,6 @@
 import logging
 
 from flask import Blueprint, jsonify, request, url_for
-from flask_login import login_required
 from werkzeug.utils import secure_filename
 
 from services.artwork_analysis_service import analyze_artwork
@@ -33,7 +32,6 @@ def process_analysis_vision() -> tuple[dict, int]:
 # New Analyze Route
 # ==========================================================================
 @bp.route("/analyze/<aspect>/<filename>", methods=["POST"])
-@login_required
 def analyze_route(aspect: str, filename: str):
     """Analyse an uploaded artwork and return redirect info."""
     safe_name = secure_filename(filename)

--- a/routes/artwork_routes.py
+++ b/routes/artwork_routes.py
@@ -19,7 +19,6 @@ from flask import (
     send_file,
     url_for,
 )
-from flask_login import login_required
 from werkzeug.utils import secure_filename, safe_join
 
 import json
@@ -91,7 +90,6 @@ def _serve_from_base(base: Path, subpath: str):
 # 2. Upload Handling
 # ==========================================================================
 @bp.route("/upload", methods=["GET", "POST"])
-@login_required
 def upload_artwork():
     """Handle new artwork file uploads with derivative generation."""
     if request.method == "POST":
@@ -156,21 +154,18 @@ def upload_artwork():
 # 3. Image Serving Routes
 # ==========================================================================
 @bp.route("/unanalysed/<path:filename>")
-@login_required
 def unanalysed_image(filename: str):
     """Serve raw uploaded artwork awaiting analysis."""
     return _serve_from_base(config.UNANALYSED_ARTWORK_DIR, filename)
 
 
 @bp.route("/processed/<path:filename>")
-@login_required
 def processed_image(filename: str):
     """Serve processed artwork images."""
     return _serve_from_base(config.PROCESSED_ARTWORK_DIR, filename)
 
 
 @bp.route("/finalised/<path:filename>")
-@login_required
 def finalised_image(filename: str):
     """Serve finalised artwork images."""
     return _serve_from_base(config.FINALISED_ARTWORK_DIR, filename)

--- a/routes/auth_routes.py
+++ b/routes/auth_routes.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+"""Authentication routes."""
+
+from flask import Blueprint, flash, redirect, render_template, request, url_for
+
+from utils.security import (
+    current_user_id,
+    login_user,
+    logout_user,
+    verify_password,
+)
+from utils.user_manager import get_user, get_user_by_username
+
+bp = Blueprint("auth", __name__)
+
+
+@bp.route("/login", methods=["GET", "POST"])
+def login():
+    if request.method == "POST":
+        username = request.form.get("username", "")
+        password = request.form.get("password", "")
+        user = get_user_by_username(username)
+        if user and verify_password(user.password_hash, password):
+            login_user(user.id)
+            return redirect(url_for("home.home"))
+        flash("Invalid credentials", "error")
+    return render_template("login.html")
+
+
+@bp.route("/logout")
+def logout():
+    logout_user()
+    return redirect(url_for("auth.login"))
+
+
+@bp.route("/healthz")
+def health_check() -> tuple[str, int]:
+    return "OK", 200
+
+
+@bp.route("/whoami")
+def whoami() -> tuple[str, int]:
+    user_id = current_user_id()
+    user = get_user(user_id) if user_id else None
+    if user:
+        return f"Logged in as: {user.username}", 200
+    return "Unknown", 200

--- a/routes/exports_routes.py
+++ b/routes/exports_routes.py
@@ -2,13 +2,11 @@
 from __future__ import annotations
 
 from flask import Blueprint, render_template
-from flask_login import login_required
 
 bp = Blueprint("exports", __name__, url_prefix="/exports")
 
 
 @bp.route("/sellbrite")
-@login_required
 def sellbrite() -> str:
     """Render the Sellbrite exports management page."""
     return render_template("exports/sellbrite.html")

--- a/routes/home_routes.py
+++ b/routes/home_routes.py
@@ -10,7 +10,6 @@ import os
 from datetime import datetime
 
 from flask import Blueprint, redirect, render_template, url_for
-from flask_login import login_required
 
 import config
 from routes import utils as routes_utils
@@ -21,14 +20,12 @@ logger = logging.getLogger(__name__)
 
 
 @bp.route("/")
-@login_required
 def root() -> "Response":
     """Redirect the base URL to /home."""
     return redirect(url_for("home.home"))
 
 
 @bp.route("/home")
-@login_required
 def home() -> str:
     """Render the application homepage."""
     return render_template(
@@ -39,7 +36,6 @@ def home() -> str:
 
 
 @bp.route("/artworks")
-@login_required
 def artworks() -> str:
     """List all unanalysed artworks ready for processing."""
     try:
@@ -63,7 +59,6 @@ def artworks() -> str:
 
 
 @bp.route("/finalised")
-@login_required
 def finalised() -> str:
     """Render the finalised artworks page."""
     return render_template(

--- a/templates/codex-library/Overlay-Menu-Design-Template/footer.html
+++ b/templates/codex-library/Overlay-Menu-Design-Template/footer.html
@@ -4,7 +4,7 @@
       <h4>Navigate</h4>
       <ul>
         <li><a href="{{ url_for('home.home') }}">Home</a></li>
-        <li><a href="{{ url_for('login') }}">Login</a></li>
+        <li><a href="{{ url_for('auth.login') }}">Login</a></li>
       </ul>
     </div>
     <div class="footer-column">

--- a/templates/main.html
+++ b/templates/main.html
@@ -75,7 +75,7 @@
                     <li><a href="{{ url_for('admin.dashboard') }}">Admin Dashboard</a></li>
                     <li><a href="{{ url_for('admin.security_page') }}">Admin Security</a></li>
                     <li><a href="#">Description Editor (GDWS)</a></li>
-                    <li><a href="{{ url_for('login') }}">Login</a></li>
+                    <li><a href="{{ url_for('auth.login') }}">Login</a></li>
                 </ul>
             </div>
         </nav>
@@ -129,7 +129,7 @@
                 <h4>Navigate</h4>
                 <ul>
                     <li><a href="{{ url_for('home.home') }}">Home</a></li>
-                    <li><a href="{{ url_for('login') }}">Login</a></li>
+                    <li><a href="{{ url_for('auth.login') }}">Login</a></li>
                 </ul>
             </div>
             <div class="footer-column">

--- a/templates/partials/footer.html
+++ b/templates/partials/footer.html
@@ -4,7 +4,7 @@
       <h4>Navigate</h4>
       <ul>
         <li><a href="{{ url_for('home.home') }}">Home</a></li>
-        <li><a href="{{ url_for('login') }}">Login</a></li>
+        <li><a href="{{ url_for('auth.login') }}">Login</a></li>
       </ul>
     </div>
     <div class="footer-column">

--- a/tests/app.py
+++ b/tests/app.py
@@ -9,8 +9,5 @@ spec = importlib.util.spec_from_file_location("real_app", ROOT / "app.py")
 module = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(module)
 
-# Re-export selected attributes for tests
+# Re-export the application factory for tests
 create_app = module.create_app
-login_manager = module.login_manager
-User = module.User
-USERS = module.USERS

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility modules for DreamArtMachine."""

--- a/utils/security.py
+++ b/utils/security.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+"""Security helpers for authentication."""
+
+from typing import Optional
+
+from flask import session
+from passlib.context import CryptContext
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+def hash_password(password: str) -> str:
+    """Return a secure password hash."""
+    return pwd_context.hash(password)
+
+
+def verify_password(hashed: str, password: str) -> bool:
+    """Verify a provided password against the stored hash."""
+    try:
+        return pwd_context.verify(password, hashed)
+    except Exception:
+        return False
+
+
+def login_user(user_id: int) -> None:
+    """Store the user in the session."""
+    session["user_id"] = user_id
+
+
+def logout_user() -> None:
+    """Remove the user from the session."""
+    session.pop("user_id", None)
+
+
+def current_user_id() -> Optional[int]:
+    """Return the currently logged-in user's ID, if any."""
+    return session.get("user_id")
+
+
+def is_authenticated() -> bool:
+    """Return True if a user is logged in."""
+    return current_user_id() is not None

--- a/utils/user_manager.py
+++ b/utils/user_manager.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+"""User management helpers backed by SQLAlchemy."""
+
+from typing import Optional
+
+from sqlalchemy import Column, Integer, String
+from sqlalchemy.orm import Session
+
+from db import Base, get_session
+from utils.security import hash_password
+
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    username = Column(String(80), unique=True, nullable=False)
+    password_hash = Column(String(255), nullable=False)
+
+
+def get_user(user_id: int) -> Optional[User]:
+    session: Session = get_session()
+    try:
+        return session.get(User, user_id)
+    finally:
+        session.close()
+
+
+def get_user_by_username(username: str) -> Optional[User]:
+    session: Session = get_session()
+    try:
+        return session.query(User).filter_by(username=username).first()
+    finally:
+        session.close()
+
+
+def create_user(username: str, password: str) -> User:
+    session: Session = get_session()
+    user = User(username=username, password_hash=hash_password(password))
+    session.add(user)
+    session.commit()
+    session.refresh(user)
+    session.close()
+    return user
+
+
+def ensure_default_users() -> None:
+    """Create default users if they do not exist."""
+    session: Session = get_session()
+    try:
+        existing = session.query(User).count()
+        if existing == 0:
+            session.add(User(username="robbie", password_hash=hash_password("Kanga123!")))
+            session.add(User(username="backup", password_hash=hash_password("DreamArt@2025")))
+            session.commit()
+    finally:
+        session.close()


### PR DESCRIPTION
## Summary
- switch to SQLAlchemy-backed user storage with default users
- add session-based security utilities and auth blueprint
- enforce login via before_request hook and update templates

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689550cf31c4832e8bf8190359c07331