### PR TITLE
Fix artwork grid and analysis pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 2025-08-08
+- Fix artwork grid layout and global container spacing.
+- Repair analysis pipeline with path-safe routing and updated OpenAI client.

--- a/services/artwork_analysis_service.py
+++ b/services/artwork_analysis_service.py
@@ -1,4 +1,5 @@
 """Artwork analysis service for DreamArtMachine."""
+
 from __future__ import annotations
 
 import base64
@@ -51,7 +52,9 @@ def analyze_artwork(filename: str) -> str:
         logger.error("Analysis failed for %s", filename)
         raise FileNotFoundError(filename)
 
-    slug = sanitize_slug(Path(filename).stem)
+    stem = Path(filename).stem
+    stem = stem.replace("-ANALYSE", "").replace("-analyse", "")
+    slug = sanitize_slug(stem)
     slug_dir = (PROCESSED_ARTWORK_DIR / slug).resolve()
     slug_dir.mkdir(parents=True, exist_ok=True)
 
@@ -89,7 +92,7 @@ def _perform_analysis(slug: str, image: Path) -> Tuple[Dict[str, Any], bytes]:
     api_key = os.getenv("OPENAI_API_KEY")
     if OpenAI and api_key:
         try:  # pragma: no cover - network dependent
-            client = OpenAI(api_key=api_key)
+            client = OpenAI()
             with img_path.open("rb") as fh:
                 resp = client.images.generate_variation(
                     model="gpt-image-1", image=fh, timeout=30
@@ -146,4 +149,3 @@ def _update_master_paths(
     with tmp.open("w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
     tmp.replace(MASTER_ARTWORK_PATHS_FILE)
-

--- a/static/css/art-cards.css
+++ b/static/css/art-cards.css
@@ -9,23 +9,36 @@
 .gallery-section { margin: 2.5em auto 3.5em auto; max-width: 78.125rem; padding: 0 1em;}
 
 /* FIX: Adjusted the minmax value to better achieve a 5-column layout on wide screens */
-.artwork-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); gap: 1.5em; margin-bottom: 2em;}
+.artwork-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 1.5em; margin-bottom: 2em; }
+
+/* Responsive grid breakpoints */
+@media (max-width: 1800px) {
+  .artwork-grid { grid-template-columns: repeat(4, 1fr); }
+}
+@media (max-width: 1400px) {
+  .artwork-grid { grid-template-columns: repeat(3, 1fr); }
+}
+@media (max-width: 1000px) {
+  .artwork-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 600px) {
+  .artwork-grid { grid-template-columns: 1fr; }
+}
 
 .gallery-card { position: relative; background: var(--card-bg); border: 0.0625rem solid var(--card-border, #000); box-shadow: var(--shadow); display: flex; flex-direction: column; align-items: center; transition: box-shadow 0.18s, transform 0.12s; min-height: 22.8125rem; padding: 0.625rem; overflow: hidden;}
 .gallery-card:hover { box-shadow: 0 0.25rem 1rem #0002; transform: translateY(-0.25rem) scale(1.013);}
 .card-thumb { width: 100%; background: none; text-align: center; padding: 1.375rem 0 0.4375rem 0; }
-.card-img-top { max-width: 94%; max-height: 13.125rem; object-fit: cover; box-shadow: 0 0.0625rem 0.4375rem #0001; background: var(--color-background);}
+.card-img-top { width: 100%; aspect-ratio: 4 / 5; object-fit: cover; box-shadow: 0 0.0625rem 0.4375rem #0001; background: var(--color-background); }
 .card-img-top.placeholder {
   display: flex;
   align-items: center;
   justify-content: center;
-  width: 94%;
-  max-width: 94%;
-  height: 13.125rem;
-  max-height: 13.125rem;
+  width: 100%;
+  aspect-ratio: 4 / 5;
   background: var(--color-card-bg);
   color: var(--color-text);
 }
+
 .card-details { flex: 1 1 auto; width: 100%; text-align: center; padding: 0.75rem 0.8125rem 1.25rem 0.8125rem; display: flex; flex-direction: column; gap: 0.625rem;}
 .card-title { font-size: 0.9em; font-weight: 400; line-height: 1.2; color: var(--main-txt); min-height: 3em; margin-bottom: 0.4375rem;}
 .card-details .btn { margin-top: 0.4375rem; width: 90%; min-width: 5.625rem;}
@@ -164,7 +177,7 @@
 
 /* Responsive Art Cards */
 @media (max-width: 1023px) {
-  .artwork-grid { gap: 1.3em; }
+  .artwork-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 1.5em; margin-bottom: 2em; }
   .card-thumb { padding: 0.75rem 0 0.25rem 0; }
   .card-title { font-size: 1em; }
   .finalised-grid { grid-template-columns: repeat(auto-fit, minmax(13.75rem, 1fr)); }

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -1,7 +1,25 @@
+:root {
+  --header-h: 80px;
+}
+
 /* ========================================================
    layout.css – Layout, Grids, Columns, Structure
    Uses --header-bg variable for theme-aware headers.
    ======================================================== */
+
+/* === Global Container === */
+.container, .page-content {
+    max-width: 2400px;
+    width: 100%;
+    margin: 0 auto;
+    padding: 0 1rem;
+}
+@media (min-width: 600px) {
+    .container, .page-content { padding: 0 2rem; }
+}
+@media (min-width: 1200px) {
+    .container, .page-content { padding: 0 3rem; }
+}
 
 /* === Layout Grids, Columns & Rows === */
 .review-artwork-grid, .row { display: flex; flex-wrap: wrap; gap: 2.5rem; align-items: flex-start; width: 100%; }
@@ -75,7 +93,7 @@
         justify-content: space-between;
         align-items: center;
         padding: 1rem 1rem;
-        width: 100vw;
+        width: 100%;
         margin: 0 auto;
         left: 0;
         right: 0;
@@ -85,7 +103,7 @@
 .site-header {
 	position: sticky;
 	top: 0;
-	z-index: 100;
+	z-index: 1000;
 	background-color: var(--header-bg);
 	transition: background-color 0.3s, color 0.3s;
 	border-bottom: 1px solid var(--color-header-border);
@@ -94,7 +112,7 @@
 
 /* FIX: Added padding-top to the main content area */
 main {
-    padding-top: 2rem;
+    padding-top: var(--header-h);
 }
 
 .header-left, .header-right {
@@ -144,7 +162,7 @@ main {
         flex-direction: column;
         justify-content: center;
         border-top: 1px solid var(--color-footer-border);
-        width: 100vw;
+        width: 100%;
         margin-left: 0;
         margin-right: 0;
         left: 0;

--- a/static/js/artworks.js
+++ b/static/js/artworks.js
@@ -99,7 +99,8 @@ function runAnalyze(card, provider, filename) {
   // Get the aspect ratio from the card's data attribute
   const aspect = card.dataset.aspect;
   // Build the correct URL
-  const actionUrl = `/analyze/${encodeURIComponent(aspect)}/${encodeURIComponent(filename)}`;
+  const encodedFilename = filename.split('/').map(encodeURIComponent).join('/');
+  const actionUrl = `/analyze/${encodeURIComponent(aspect)}/${encodedFilename}`;
 
   const formData = new FormData();
   formData.append('provider', provider);

--- a/templates/artworks.html
+++ b/templates/artworks.html
@@ -1,31 +1,33 @@
 {% extends "main.html" %}
 {% block title %}Artworks | DreamArtMachine{% endblock %}
 {% block content %}
-<h1><img src="{{ url_for('static', filename='icons/svg/light/number-circle-two-light.svg') }}" class="hero-step-icon" alt="Step 2: Artwork" />Artwork</h1>
-<p class="page-description">Browse and analyze uploaded artworks.</p>
-<section class="main-content">
-  {% if artworks %}
-  <div class="gallery-grid">
-    {% for art in artworks %}
-    <div class="gallery-card" data-analyse="{{ art.analyse or '' }}" data-aspect="{{ art.aspect }}" data-sku="{{ art.sku }}">
-      {% if art.thumb_path %}
-      <img src="{{ get_artwork_image_url('unanalysed', art.thumb_path) }}" alt="{{ art.slug }}" class="card-img-top">
-      {% else %}
-      <div class="card-img-top placeholder">No thumbnail</div>
-      {% endif %}
-      <div class="card-body">
-        <h3 class="card-title">{{ art.filename }}</h3>
-        <div class="card-meta">SKU: {{ art.sku }}<br>Uploaded: {{ art.upload_date }}</div>
-        <button class="btn btn-primary btn-analyze" data-provider="openai">Analyze</button>
+<div class="page-content">
+  <h1><img src="{{ url_for('static', filename='icons/svg/light/number-circle-two-light.svg') }}" class="hero-step-icon" alt="Step 2: Artwork" />Artwork</h1>
+  <p class="page-description">Browse and analyze uploaded artworks.</p>
+  <section class="main-content">
+    {% if artworks %}
+    <div class="artwork-grid">
+      {% for art in artworks %}
+      <div class="gallery-card" data-analyse="{{ art.analyse or '' }}" data-aspect="{{ art.aspect }}" data-sku="{{ art.sku }}">
+        {% if art.thumb_path %}
+        <img src="{{ get_artwork_image_url('unanalysed', art.thumb_path) }}" alt="{{ art.slug }}" class="card-img-top">
+        {% else %}
+        <div class="card-img-top placeholder">No thumbnail</div>
+        {% endif %}
+        <div class="card-body">
+          <h3 class="card-title">{{ art.filename }}</h3>
+          <div class="card-meta">SKU: {{ art.sku }}<br>Uploaded: {{ art.upload_date }}</div>
+          <button class="btn btn-primary btn-analyze" data-provider="openai">Analyze</button>
+        </div>
+        <div class="card-overlay hidden"></div>
       </div>
-      <div class="card-overlay hidden"></div>
+      {% endfor %}
     </div>
-    {% endfor %}
-  </div>
-  {% else %}
-  <p>No artworks uploaded yet.</p>
-  {% endif %}
-</section>
+    {% else %}
+    <p>No artworks uploaded yet.</p>
+    {% endif %}
+  </section>
+</div>
 {% endblock %}
 {% block scripts %}
 <script src="{{ url_for('static', filename='js/artworks.js') }}"></script>

--- a/tests/test_analyze_route.py
+++ b/tests/test_analyze_route.py
@@ -1,0 +1,57 @@
+import importlib.util
+import shutil
+from pathlib import Path
+import sys
+
+import pytest
+from PIL import Image
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.append(str(ROOT))
+import config
+
+spec = importlib.util.spec_from_file_location("real_app", ROOT / "app.py")
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+create_app = module.create_app
+
+
+@pytest.fixture
+def client():
+    app = create_app()
+    app.config["TESTING"] = True
+    return app.test_client()
+
+
+def login(client):
+    return client.post("/login", data={"username": "robbie", "password": "Kanga123!"})
+
+
+def _create_image(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    img = Image.new("RGB", (10, 10), color="white")
+    img.save(path)
+
+
+def test_analyze_route_smoke(client):
+    login(client)
+    slug = "test-art"
+    filename = f"{slug}-ANALYSE.jpg"
+    rel_path = Path(slug) / filename
+    _create_image(config.UNANALYSED_ARTWORK_DIR / rel_path)
+
+    resp = client.post(
+        f"/analyze/square/{rel_path}",
+        data={"provider": "openai"},
+        headers={"X-Requested-With": "XMLHttpRequest"},
+    )
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["success"] is True
+    assert "redirect_url" in data
+
+    processed_img = config.PROCESSED_ARTWORK_DIR / slug / f"{slug}.jpg"
+    assert processed_img.exists()
+
+    shutil.rmtree(config.PROCESSED_ARTWORK_DIR / slug, ignore_errors=True)
+    shutil.rmtree(config.UNANALYSED_ARTWORK_DIR / slug, ignore_errors=True)


### PR DESCRIPTION
## Summary
- enforce 2400px centered container with sticky header offset
- add 5→1 responsive artwork grid and safe analyze endpoint
- upgrade analysis service slug handling and OpenAI client

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895728c5b1c832ebb89b452f5f7994e